### PR TITLE
fix tail: cannot open '+2' for reading: No such file or directory

### DIFF
--- a/nix/builders/neovimWrapper.nix
+++ b/nix/builders/neovimWrapper.nix
@@ -117,7 +117,7 @@ let
         head -1 ${placeholder "out"}/bin/${name} > $BASHCACHE
         # Add code
         cat ${preWrapperShellFile} >> $BASHCACHE
-        tail +2 ${placeholder "out"}/bin/${name} >> $BASHCACHE
+        tail -n +2 ${placeholder "out"}/bin/${name} >> $BASHCACHE
         cat $BASHCACHE > ${placeholder "out"}/bin/${name}
         rm $BASHCACHE
       ''


### PR DESCRIPTION
Running your template flake gives me this exception:

```
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
no Makefile or custom buildPhase, doing nothing
Generating remote plugin manifest
Looking for lua dependencies...
_addToLuaPath called for dir /nix/store/naynwkgl2pwnbl5vmcljys2wiidr568i-nv-rtp
newpath: /nix/store/bhn7kr9rscvnjy5kxbhvw7ixdjwhnkg1-lua5.1-luassert-1.9.0-1
_addToLuaPath called for dir /nix/store/bhn7kr9rscvnjy5kxbhvw7ixdjwhnkg1-lua5.1-luassert-1.9.0-1
newpath: /nix/store/gdjhjqfhx153xsazmq3d72hvzfcgmkqj-lua5.1-say-1.4.1-3
_addToLuaPath called for dir /nix/store/gdjhjqfhx153xsazmq3d72hvzfcgmkqj-lua5.1-say-1.4.1-3
newpath: /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
_addToLuaPath called for dir /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
newpath: /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
_addToLuaPath called for dir /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
/nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5 already parsed
newpath: /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
_addToLuaPath called for dir /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
/nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5 already parsed
newpath: /nix/store/k0s4b632514y6g950jzvjfdqqzf1jjs7-lua5.1-plenary.nvim-scm-1
_addToLuaPath called for dir /nix/store/k0s4b632514y6g950jzvjfdqqzf1jjs7-lua5.1-plenary.nvim-scm-1
newpath: /nix/store/bhn7kr9rscvnjy5kxbhvw7ixdjwhnkg1-lua5.1-luassert-1.9.0-1
_addToLuaPath called for dir /nix/store/bhn7kr9rscvnjy5kxbhvw7ixdjwhnkg1-lua5.1-luassert-1.9.0-1
/nix/store/bhn7kr9rscvnjy5kxbhvw7ixdjwhnkg1-lua5.1-luassert-1.9.0-1 already parsed
newpath: /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
_addToLuaPath called for dir /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
/nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5 already parsed
newpath: /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
_addToLuaPath called for dir /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
/nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5 already parsed
newpath: /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
_addToLuaPath called for dir /nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5
/nix/store/h8alfg9b0fqn1yzh9pwy1pmjb4m1ww92-lua-5.1.5 already parsed
#################################################
LUA_PATH: ;;;/nix/store/bhn7kr9rscvnjy5kxbhvw7ixdjwhnkg1-lua5.1-luassert-1.9.0-1/share/lua/5.1/?.lua;/nix/store/bhn7kr9rscvnjy5kxbhvw7ixdjwhnkg1-lua5.1-lua>
LUA_CPATH: ;;
#################################################
tail: cannot open '+2' for reading: No such file or directory
```

I tracked it down to `neovimWrapper` generating a bash script with this command:

```bash
tail +2 ${placeholder "out"}/bin/${name} >> $BASHCACHE
```

it seems that `tail` interprets `+2` as the file on my system for some reason, but to be fair `tail +n` without the `-n` option has been obsolete for quite some time.

I am running macOS.

I just added the `-n` and it fixed it.

Out of curiosity, what system are you using?

Thanks for writing `nv` by the way