### PR TITLE
Better errors

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -211,7 +211,7 @@
 
       aliases = [ "vim" "vi" "nvim" ];
 
-      customSubs = with pkgs.vimPlugins patchUtils; [];
+      customSubs = with patchUtils; [];
             # For example, if you want to add a plugin with the short url
             # "cool/plugin" which is in nixpkgs as plugin-nvim you would do:
             # ++ (patchUtils.githubUrlSub "cool/plugin" plugin-nvim);

--- a/templates/configV1/flake.nix
+++ b/templates/configV1/flake.nix
@@ -96,7 +96,7 @@
 
       # Custom subsitutions you want the patcher to make. Custom subsitutions 
       # can be generated using
-      customSubs = with pkgs.vimPlugins patchUtils; [];
+      customSubs = with patchUtils; [];
             # For example, if you want to add a plugin with the short url
             # "cool/plugin" which is in nixpkgs as plugin-nvim you would do:
             # ++ (patchUtils.githubUrlSub "cool/plugin" plugin-nvim);


### PR DESCRIPTION
Previously, as mentioned in https://github.com/NicoElbers/nv/issues/8, broken assertions in the zig code would
generate cryptic error messages. A bunch of these assertions however
could be triggered by user behavior, like accidentally trying to include
a plugin twice, or through an incorrect assumption in nixpkgs.

In situations like these, I now have more sensible readable error
messages with potential fixes.

Besides this, I found a small bug in customSubs, which I have a hotfix for. I don't know nix well enough :')